### PR TITLE
fix: use correct property names to sort horizontally cut subpieces

### DIFF
--- a/src/components/onion/Onion.PieceAnalyzer.svelte
+++ b/src/components/onion/Onion.PieceAnalyzer.svelte
@@ -56,7 +56,7 @@
 				return piece.subPieces.length
 					? piece.subPieces.map(({ subPieceArea, horizontalCutPathNum }) => ({
 							...pieceForSVG,
-							pieceArea: subPieceArea,
+							area: subPieceArea,
 							subPieceIndex: horizontalCutPathNum
 					  }))
 					: pieceForSVG;

--- a/src/utils/onion.js
+++ b/src/utils/onion.js
@@ -166,7 +166,7 @@ export default class Onion {
 							if (subPieces.length) {
 								// add the third piece on the bottom
 								// in this block, upperPieceArea is actually the top 2/3 pieces' area
-								const topPieceArea = subPieces[0];
+								const topPieceArea = subPieces[0].subPieceArea;
 
 								subPieces = [
 									{
@@ -439,7 +439,7 @@ export default class Onion {
 
 						if (subPieces.length) {
 							// in this block, upperPieceArea is actually the top 2/3 pieces' area
-							const topPieceArea = subPieces[0];
+							const topPieceArea = subPieces[0].subPieceArea;
 
 							subPieces = [
 								{


### PR DESCRIPTION
fixes #34 

b690e1b78f52eb8f6eff8489d5ff19660d6284a7 fixes the vertical bug seen in https://github.com/the-pudding/onion/issues/34#issue-2775967531

4882f21db35fc58f3391431b392dfd9b42543bbb fixes the radial bug seen in https://github.com/the-pudding/onion/issues/34#issuecomment-2578281142