### PR TITLE
feat: add smooth transition between exploded/unexploded

### DIFF
--- a/src/components/Index.svelte
+++ b/src/components/Index.svelte
@@ -10,7 +10,7 @@
 	const copy = getContext("copy");
 	// const data = getContext("data");
 
-	console.log({ copy });
+	// console.log({ copy });
 </script>
 
 <WIP />

--- a/src/components/onion/Onion.Demo.svelte
+++ b/src/components/onion/Onion.Demo.svelte
@@ -1,8 +1,9 @@
 <script>
-	import { run } from 'svelte/legacy';
+	import { run } from "svelte/legacy";
 
 	import { writable } from "svelte/store";
 	import { setContext } from "svelte";
+	import { Tween } from "svelte/motion";
 	import { scaleLinear } from "d3";
 	import paper from "paper";
 	import {
@@ -212,6 +213,13 @@
 	run(() => {
 		$explodeStore = explode === "on";
 	});
+
+	// TODO tween viewBox height instead of width
+	const viewBoxWidth = new Tween(width);
+
+	$effect(() => {
+		viewBoxWidth.target = $explodeStore ? 1450 : width;
+	});
 </script>
 
 <figure class:explode={explode === "on"}>
@@ -243,45 +251,37 @@
 		</div>
 	{/if}
 
-	{#if explode === "off"}
-		<svg
-			viewBox="{-width / 2} 0 {width} {showRadialTarget
-				? height * (5 / 3)
-				: height}"
-		>
-			<!-- <OnionAxisX {width} {height} /> -->
-			<OnionAxisX {width} {height} isBottom isHalfWidth={showRadialTarget} />
-			<!-- TODO responsive sizing: move y axis when screen resizes -->
-			<!-- <OnionAxisY {height} /> -->
+	<svg
+		viewBox="{-width / 2} 0 {viewBoxWidth.current} {showRadialTarget
+			? height * (5 / 3)
+			: height}"
+	>
+		<!-- <OnionAxisX {width} {height} /> -->
+		<OnionAxisX {width} {height} isBottom isHalfWidth={showRadialTarget} />
+		<!-- TODO responsive sizing: move y axis when screen resizes -->
+		<!-- <OnionAxisY {height} /> -->
 
-			<OnionLayers {height} />
+		<OnionLayers {height} />
 
-			{#if showCuts}
-				<OnionCuts {width} {height} {yScale} />
-			{/if}
+		{#if showCuts}
+			<OnionCuts {width} {height} {yScale} />
+		{/if}
 
-			{#if showRadialTarget}
-				<clipPath id="layer-mask">
-					<rect {width} {height} x={-width / 2} />
-				</clipPath>
+		{#if showRadialTarget}
+			<clipPath id="layer-mask">
+				<rect {width} {height} x={-width / 2} />
+			</clipPath>
 
-				<circle
-					r="10"
-					cx="0"
-					cy={yScale(-cutTargetDepth)}
-					class="radial-target"
-				/>
-			{/if}
+			<circle
+				r="10"
+				cx="0"
+				cy={yScale(-cutTargetDepth)}
+				class="radial-target"
+			/>
+		{/if}
 
-			{#key $onionStore}
-				<OnionPieceAnalyzer {yScale} {highlightExtremes} />
-			{/key}
-		</svg>
-	{:else if explode === "on"}
-		{#key $onionStore}
-			<OnionPieceAnalyzer {yScale} highlightExtremes={false} />
-		{/key}
-	{/if}
+		<OnionPieceAnalyzer {yScale} {highlightExtremes} />
+	</svg>
 
 	{#if showControls}
 		<div class="controls bottom">
@@ -344,6 +344,7 @@
 		--demo-spacing-y: 1rem;
 		--demo-spacing-x: 2rem;
 		--axis-thickness: 2;
+		--duration-transform: 800ms;
 	}
 
 	figure {

--- a/src/components/onion/Onion.Demo.svelte
+++ b/src/components/onion/Onion.Demo.svelte
@@ -276,7 +276,9 @@
 			/>
 		{/if}
 
-		<OnionPieceAnalyzer {yScale} {highlightExtremes} />
+		{#key $onionStore}
+			<OnionPieceAnalyzer {yScale} {highlightExtremes} />
+		{/key}
 	</svg>
 
 	{#if showControls}

--- a/src/components/onion/Onion.Demo.svelte
+++ b/src/components/onion/Onion.Demo.svelte
@@ -341,6 +341,7 @@
 		--demo-spacing-x: 2rem;
 		--axis-thickness: 2;
 		--duration-transform: 800ms;
+		--duration-fade: 200ms;
 	}
 
 	figure {
@@ -350,11 +351,12 @@
 
 	:global(line, circle) {
 		stroke: black;
-		transition: stroke 200ms;
+		transition: stroke var(--duration-fade) var(--duration-transform);
 	}
 
 	:global(.explode :is(line, circle)) {
 		stroke: transparent;
+		transition: stroke var(--duration-fade);
 	}
 
 	.radial-target {

--- a/src/components/onion/Onion.Demo.svelte
+++ b/src/components/onion/Onion.Demo.svelte
@@ -60,6 +60,7 @@
 	} = $props();
 
 	const width = 600;
+	setContext("width", width);
 	const height = width / 2;
 	const radius = height * 0.8;
 	// SVG drawing is flipped upside down
@@ -215,11 +216,6 @@
 	});
 
 	// TODO tween viewBox height instead of width
-	const viewBoxWidth = new Tween(width);
-
-	$effect(() => {
-		viewBoxWidth.target = $explodeStore ? 1450 : width;
-	});
 </script>
 
 <figure class:explode={explode === "on"}>
@@ -252,7 +248,7 @@
 	{/if}
 
 	<svg
-		viewBox="{-width / 2} 0 {viewBoxWidth.current} {showRadialTarget
+		viewBox="{-width / 2} 0 {width} {showRadialTarget
 			? height * (5 / 3)
 			: height}"
 	>

--- a/src/components/onion/Onion.Demo.svelte
+++ b/src/components/onion/Onion.Demo.svelte
@@ -215,7 +215,7 @@
 		$explodeStore = explode === "on";
 	});
 
-	// TODO tween viewBox height instead of width
+	let viewBoxHeight = $state(new Tween(height));
 </script>
 
 <figure class:explode={explode === "on"}>
@@ -247,11 +247,7 @@
 		</div>
 	{/if}
 
-	<svg
-		viewBox="{-width / 2} 0 {width} {showRadialTarget
-			? height * (5 / 3)
-			: height}"
-	>
+	<svg viewBox="{-width / 2} 0 {width} {viewBoxHeight.current}">
 		<!-- <OnionAxisX {width} {height} /> -->
 		<OnionAxisX {width} {height} isBottom isHalfWidth={showRadialTarget} />
 		<!-- TODO responsive sizing: move y axis when screen resizes -->
@@ -277,7 +273,12 @@
 		{/if}
 
 		{#key $onionStore}
-			<OnionPieceAnalyzer {yScale} {highlightExtremes} />
+			<OnionPieceAnalyzer
+				{yScale}
+				{highlightExtremes}
+				{showRadialTarget}
+				bind:viewBoxHeight
+			/>
 		{/key}
 	</svg>
 

--- a/src/components/onion/Onion.Piece.svelte
+++ b/src/components/onion/Onion.Piece.svelte
@@ -107,7 +107,7 @@
 	:global(figure.explode path) {
 		stroke: black;
 		transition:
-			stroke 200ms,
-			transform var(--duration-transform);
+			stroke var(--duration-fade),
+			transform var(--duration-transform) var(--duration-fade);
 	}
 </style>

--- a/src/components/onion/Onion.Piece.svelte
+++ b/src/components/onion/Onion.Piece.svelte
@@ -11,6 +11,7 @@
 	 * @property {boolean} [highlight]
 	 * @property {boolean} [primary]
 	 * @property {boolean} [secondary]
+	 * @property {number} explodedRowY
 	 */
 
 	/** @type {Props} */
@@ -22,7 +23,8 @@
 		subPieceIndex = undefined,
 		highlight = false,
 		primary = false,
-		secondary = false
+		secondary = false,
+		explodedRowY
 	} = $props();
 
 	const subpiece = subPieceIndex !== undefined;
@@ -36,6 +38,8 @@
 	const cutPathStore = getContext("cutPathStore");
 	const horizontalCutPathStore = getContext("horizontalCutPathStore");
 
+	// TODO this intersection logic was moved to OnionPieceAnalyzer;
+	//   it can be removed from here after radial pieces can smoothly transition to exploded
 	let layerPath = $derived($layerPathStore[layerNum]);
 	let cutPath = $derived($cutPathStore[cutNum]);
 	let piecePath = $derived(layerPath.intersect(cutPath));
@@ -49,16 +53,12 @@
 
 	const colorScaleStore = getContext("colorScaleStore");
 
-	// TODO move pieces to new row if they won't fit in the current one
 	let explodedX = $derived(
-		width / 2 - piecePath.position.x - 300 + (width + 2) * index
+		width / 2 - piecePath.position.x - 300 + width * index
 	);
-	let explodedY = $derived(height / 2 - piecePath.position.y);
+	let explodedY = $derived(height / 2 - piecePath.position.y + explodedRowY);
 </script>
 
-<!-- TODO can we prevent highlighted pieces next to y-axis from being truncated on the left? -->
-<!--   (involves setting viewBox when $explodeStore === false) -->
-<!--   (requires us to manually position each piece's SVG element) -->
 <!-- {#if subpiece}
 		{@debug piecePath, subPiecePath, d, area}
 	{/if} -->
@@ -81,10 +81,6 @@
 />
 
 <style>
-	/**
-	* TODO transform transition looks interesting,
-	* but is there a way to animate transition between exploded and not exploded?
-	*/
 	path {
 		fill: none;
 		stroke: transparent;

--- a/src/components/onion/Onion.Piece.svelte
+++ b/src/components/onion/Onion.Piece.svelte
@@ -3,6 +3,7 @@
 
 	/**
 	 * @typedef {Object} Props
+	 * @property {any} path
 	 * @property {any} area
 	 * @property {any} layerNum
 	 * @property {any} cutNum
@@ -16,6 +17,7 @@
 
 	/** @type {Props} */
 	let {
+		path,
 		area,
 		layerNum,
 		cutNum,
@@ -27,6 +29,8 @@
 		explodedRowY
 	} = $props();
 
+	const d = path.pathData;
+	const { height } = path.strokeBounds;
 	const subpiece = subPieceIndex !== undefined;
 	const svgPadding = 1;
 
@@ -39,32 +43,17 @@
 		numHorizontalCuts
 	} = $derived($onionStore);
 
-	const layerPathStore = getContext("layerPathStore");
-	const cutPathStore = getContext("cutPathStore");
 	const horizontalCutPathStore = getContext("horizontalCutPathStore");
-
-	// TODO this intersection logic was moved to OnionPieceAnalyzer;
-	//   it can be removed from here after radial pieces can smoothly transition to exploded
-	let layerPath = $derived($layerPathStore[layerNum]);
-	let cutPath = $derived($cutPathStore[cutNum]);
-	let piecePath = $derived(layerPath.intersect(cutPath));
-	let subPiecePath = $derived(
-		piecePath.intersect($horizontalCutPathStore[subPieceIndex])
-	);
-	let { width, height } = $derived(piecePath.strokeBounds);
-	let d = $derived((subpiece ? subPiecePath : piecePath).pathData);
-
 	const explodeStore = getContext("explodeStore");
-
 	const colorScaleStore = getContext("colorScaleStore");
 
 	let explodedY = $derived.by(() => {
-		let explodedY = height / 2 - piecePath.position.y + explodedRowY;
+		let explodedY = height / 2 - path.position.y + explodedRowY;
 
 		// shift lower subpieces upward
 		if (subpiece) {
 			for (let i = subPieceIndex; i < numHorizontalCuts; i++) {
-				const upperSubPiecePath = piecePath.intersect(
+				const upperSubPiecePath = path.intersect(
 					$horizontalCutPathStore[i + 1]
 				);
 				explodedY -= upperSubPiecePath.strokeBounds.height;
@@ -76,7 +65,7 @@
 </script>
 
 <!-- {#if subpiece}
-		{@debug piecePath, subPiecePath, d, area}
+		{@debug path, subPiecePath, d, area}
 	{/if} -->
 <path
 	{d}

--- a/src/components/onion/Onion.Piece.svelte
+++ b/src/components/onion/Onion.Piece.svelte
@@ -62,18 +62,13 @@
 		let explodedY = height / 2 - piecePath.position.y + explodedRowY;
 
 		// shift lower subpieces upward
-		// TODO handle an arbitrary number of h-cuts
-
-		// handle 1 h-cut
-		if (subPieceIndex === 0) {
-			const upperSubPiecePath = piecePath.intersect($horizontalCutPathStore[1]);
-			explodedY -= upperSubPiecePath.strokeBounds.height;
-		}
-
-		// handle 2 h-cuts
-		if (numHorizontalCuts === 2 && subPieceIndex < 2) {
-			const topSubPiecePath = piecePath.intersect($horizontalCutPathStore[2]);
-			explodedY -= topSubPiecePath.strokeBounds.height;
+		if (subpiece) {
+			for (let i = subPieceIndex; i < numHorizontalCuts; i++) {
+				const upperSubPiecePath = piecePath.intersect(
+					$horizontalCutPathStore[i + 1]
+				);
+				explodedY -= upperSubPiecePath.strokeBounds.height;
+			}
 		}
 
 		return explodedY;

--- a/src/components/onion/Onion.Piece.svelte
+++ b/src/components/onion/Onion.Piece.svelte
@@ -12,7 +12,7 @@
 	 * @property {boolean} [primary]
 	 * @property {boolean} [secondary]
 	 * @property {number} explodedX
-	 * @property {number} explodedRowY
+	 * @property {number} explodedY
 	 */
 
 	/** @type {Props} */
@@ -26,46 +26,23 @@
 		primary = false,
 		secondary = false,
 		explodedX,
-		explodedRowY
+		explodedY
 	} = $props();
 
 	const d = path.pathData;
-	const { height } = path.strokeBounds;
 	const subpiece = subPieceIndex !== undefined;
 	const svgPadding = 1;
 
 	const onionStore = getContext("onionStore");
-	let {
-		cutType,
-		cutTargetDepthPercentage,
-		meanArea,
-		standardDeviation,
-		numHorizontalCuts
-	} = $derived($onionStore);
+	let { cutType, cutTargetDepthPercentage, meanArea, standardDeviation } =
+		$derived($onionStore);
 
-	const horizontalCutPathStore = getContext("horizontalCutPathStore");
 	const explodeStore = getContext("explodeStore");
 	const colorScaleStore = getContext("colorScaleStore");
-
-	let explodedY = $derived.by(() => {
-		let explodedY = height / 2 - path.position.y + explodedRowY;
-
-		// shift lower subpieces upward
-		if (subpiece) {
-			for (let i = subPieceIndex; i < numHorizontalCuts; i++) {
-				const upperSubPiecePath = path.intersect(
-					$horizontalCutPathStore[i + 1]
-				);
-				explodedY -= upperSubPiecePath.strokeBounds.height;
-			}
-		}
-
-		return explodedY;
-	});
 </script>
 
 <!-- {#if subpiece}
-		{@debug path, subPiecePath, d, area}
+		{@debug path, d, area}
 	{/if} -->
 <path
 	{d}

--- a/src/components/onion/Onion.Piece.svelte
+++ b/src/components/onion/Onion.Piece.svelte
@@ -53,6 +53,7 @@
 
 	const colorScaleStore = getContext("colorScaleStore");
 
+	// TODO shift upward subpieces whose subPieceIndex > 0
 	let explodedY = $derived(height / 2 - piecePath.position.y + explodedRowY);
 </script>
 

--- a/src/components/onion/Onion.Piece.svelte
+++ b/src/components/onion/Onion.Piece.svelte
@@ -3,7 +3,6 @@
 
 	/**
 	 * @typedef {Object} Props
-	 * @property {number} index
 	 * @property {any} area
 	 * @property {any} layerNum
 	 * @property {any} cutNum
@@ -17,7 +16,6 @@
 
 	/** @type {Props} */
 	let {
-		index,
 		area,
 		layerNum,
 		cutNum,

--- a/src/components/onion/Onion.Piece.svelte
+++ b/src/components/onion/Onion.Piece.svelte
@@ -11,6 +11,7 @@
 	 * @property {boolean} [highlight]
 	 * @property {boolean} [primary]
 	 * @property {boolean} [secondary]
+	 * @property {number} explodedX
 	 * @property {number} explodedRowY
 	 */
 
@@ -24,6 +25,7 @@
 		highlight = false,
 		primary = false,
 		secondary = false,
+		explodedX,
 		explodedRowY
 	} = $props();
 
@@ -53,9 +55,6 @@
 
 	const colorScaleStore = getContext("colorScaleStore");
 
-	let explodedX = $derived(
-		width / 2 - piecePath.position.x - 300 + width * index
-	);
 	let explodedY = $derived(height / 2 - piecePath.position.y + explodedRowY);
 </script>
 

--- a/src/components/onion/Onion.Piece.svelte
+++ b/src/components/onion/Onion.Piece.svelte
@@ -31,8 +31,13 @@
 	const svgPadding = 1;
 
 	const onionStore = getContext("onionStore");
-	let { cutType, cutTargetDepthPercentage, meanArea, standardDeviation } =
-		$derived($onionStore);
+	let {
+		cutType,
+		cutTargetDepthPercentage,
+		meanArea,
+		standardDeviation,
+		numHorizontalCuts
+	} = $derived($onionStore);
 
 	const layerPathStore = getContext("layerPathStore");
 	const cutPathStore = getContext("cutPathStore");
@@ -53,8 +58,26 @@
 
 	const colorScaleStore = getContext("colorScaleStore");
 
-	// TODO shift upward subpieces whose subPieceIndex > 0
-	let explodedY = $derived(height / 2 - piecePath.position.y + explodedRowY);
+	let explodedY = $derived.by(() => {
+		let explodedY = height / 2 - piecePath.position.y + explodedRowY;
+
+		// shift lower subpieces upward
+		// TODO handle an arbitrary number of h-cuts
+
+		// handle 1 h-cut
+		if (subPieceIndex === 0) {
+			const upperSubPiecePath = piecePath.intersect($horizontalCutPathStore[1]);
+			explodedY -= upperSubPiecePath.strokeBounds.height;
+		}
+
+		// handle 2 h-cuts
+		if (numHorizontalCuts === 2 && subPieceIndex < 2) {
+			const topSubPiecePath = piecePath.intersect($horizontalCutPathStore[2]);
+			explodedY -= topSubPiecePath.strokeBounds.height;
+		}
+
+		return explodedY;
+	});
 </script>
 
 <!-- {#if subpiece}
@@ -76,6 +99,7 @@
 		cutTargetDepthPercentage === 0}
 	class:subpiece
 	data-area={area}
+	data-subpiece-index={subPieceIndex}
 />
 
 <style>

--- a/src/components/onion/Onion.PieceAnalyzer.svelte
+++ b/src/components/onion/Onion.PieceAnalyzer.svelte
@@ -6,6 +6,7 @@
 	import OnionPiece from "$components/onion/Onion.Piece.svelte";
 	import { writable } from "svelte/store";
 	import { EXPLODED_GAP } from "$utils/constants";
+	import { compareRadialPieceAreasDescending } from "$utils/math";
 
 	let { yScale, highlightExtremes } = $props();
 
@@ -67,7 +68,7 @@
 						: pieceForSVG;
 				})
 			)
-			.sort((a, b) => b.area - a.area)
+			.sort(compareRadialPieceAreasDescending)
 	);
 
 	const explodeXScaleStore = writable();

--- a/src/components/onion/Onion.PieceAnalyzer.svelte
+++ b/src/components/onion/Onion.PieceAnalyzer.svelte
@@ -181,34 +181,9 @@
 <!-- TODO draw scale/ticks for exploded view? -->
 {#if cutType === "vertical"}
 	{#each verticalPiecesLaidOut as { pieces, explodedRowY }}
-		{#each pieces as { layerRadius, pieceArea, yRange, subPieceIndex, cutX, cutNum, layerNumInColumn, explodedX }, index}
+		{#each pieces as { pieceArea, subPieceIndex, cutX, cutNum, layerNumInColumn, explodedX }, index}
 			{@const isInCenterColumn = cutNum === 0}
 			{@const isBottomPiece = layerNumInColumn === 0}
-			{@const columnArcFunctions = layerArcs.filter(
-				(_, arcNum) => layerRadii[arcNum] > cutX
-			)}
-			{@const layerArcFunction =
-				columnArcFunctions[layerNumInColumn] ?? columnArcFunctions[0]}
-			{@const y = layerArcFunction(cutX)}
-			{@const cutY = yScale(y)}
-
-			<!-- <text x={cutX} y={cutY} font-size="xx-small">
-    			({Math.round(cutX)},{Math.round(y)})
-    		</text> -->
-			<!-- <circle r="2" cx={cutX} cy={cutY} fill="red" /> -->
-
-			<!-- {#if numHorizontalCuts && subPieces.length}
-    			<text
-    				x={cutX}
-    				y={cutY}
-    				font-size="xx-small"
-    				alignment-baseline="hanging"
-    				fill={yRangeColors[subPieces.length]}
-    			>
-    				y &isin; [{Math.round(yRange[0])},{Math.round(yRange[1])}]
-    				{JSON.stringify(subPieces.map(Math.round))}
-    			</text>
-    		{/if} -->
 
 			<OnionPiece
 				{index}

--- a/src/components/onion/Onion.PieceAnalyzer.svelte
+++ b/src/components/onion/Onion.PieceAnalyzer.svelte
@@ -140,6 +140,7 @@
 			// TODO should these dimensions be set in onion.js instead?
 			piece.width = width;
 			piece.height = height;
+			piece.explodedX = width / 2 - piecePath.position.x - svgWidth / 2;
 
 			const lastRowWidth = rows.length ? lastRow.explodedRowWidth : 0;
 			const remainingWidth = svgWidth - lastRowWidth;
@@ -148,6 +149,7 @@
 			// if there is enough width in the last row to fit this piece, add it
 			// TODO account for gaps between pieces
 			if (rows.length && additionalWidth <= remainingWidth) {
+				piece.explodedX += lastRowWidth;
 				lastRow.pieces.push(piece);
 				lastRow.explodedRowWidth += additionalWidth;
 			} else {
@@ -177,7 +179,7 @@
 <!-- TODO draw scale/ticks for exploded view? -->
 {#if cutType === "vertical"}
 	{#each verticalPiecesLaidOut as { pieces, explodedRowY }}
-		{#each pieces as { layerRadius, pieceArea, yRange, subPieceIndex, cutX, cutNum, layerNumInColumn }, index}
+		{#each pieces as { layerRadius, pieceArea, yRange, subPieceIndex, cutX, cutNum, layerNumInColumn, explodedX }, index}
 			{@const isInCenterColumn = cutNum === 0}
 			{@const isBottomPiece = layerNumInColumn === 0}
 			{@const columnArcFunctions = layerArcs.filter(
@@ -217,6 +219,7 @@
 				highlight={highlightExtremes}
 				primary={isInCenterColumn}
 				secondary={isBottomPiece}
+				{explodedX}
 				explodedRowY={explodedRowY ?? 0}
 			/>
 		{/each}

--- a/src/components/onion/Onion.PieceAnalyzer.svelte
+++ b/src/components/onion/Onion.PieceAnalyzer.svelte
@@ -8,7 +8,12 @@
 	import { EXPLODED_GAP } from "$utils/constants";
 	import { compareRadialPieceAreasDescending } from "$utils/math";
 
-	let { yScale, highlightExtremes } = $props();
+	let {
+		yScale,
+		highlightExtremes,
+		showRadialTarget,
+		viewBoxHeight = $bindable()
+	} = $props();
 
 	const onionStore = getContext("onionStore");
 	let {
@@ -119,6 +124,7 @@
 	const layerPathStore = getContext("layerPathStore");
 	const cutPathStore = getContext("cutPathStore");
 	const horizontalCutPathStore = getContext("horizontalCutPathStore");
+	const explodeStore = getContext("explodeStore");
 
 	// create a data structure arranges pieces in rows for exploded view
 	// ^this will be mapped over in template--whether exploded or not--so that pieces animate smoothly
@@ -193,6 +199,27 @@
 			[]
 		)
 	);
+
+	// TODO might make more sense to set viewBoxHeight.target in OnionDemo,
+	//   which would eliminate need for showRadialTarget prop here
+	$effect(() => {
+		// TODO import this value from constants file
+		const defaultWidth = 300;
+
+		viewBoxHeight.target = showRadialTarget
+			? defaultWidth * (5 / 3)
+			: explodeStore
+			  ? // increase viewBoxHeight to fit up to last row, including its tallest piece
+			    Math.max(
+						inlineLayoutPieces.at(-1).explodedRowY +
+							Math.max(
+								...inlineLayoutPieces.at(-1).pieces.map((piece) => piece.height)
+							) +
+							EXPLODED_GAP,
+						defaultWidth
+			    )
+			  : defaultWidth;
+	});
 </script>
 
 <!-- TODO draw scale/ticks for exploded view? -->

--- a/src/components/onion/Onion.PieceAnalyzer.svelte
+++ b/src/components/onion/Onion.PieceAnalyzer.svelte
@@ -122,7 +122,7 @@
 
 	// create a data structure arranges pieces in rows for exploded view
 	// ^this will be mapped over in template--whether exploded or not--so that pieces animate smoothly
-	let piecesLaidOut = $derived(
+	let inlineLayoutPieces = $derived(
 		(cutType === "vertical" ? verticalPieces : radialPieces).reduce(
 			(rows, piece) => {
 				const lastRow = rows[rows.length - 1];
@@ -180,7 +180,7 @@
 </script>
 
 <!-- TODO draw scale/ticks for exploded view? -->
-{#each piecesLaidOut as { pieces, explodedRowY }}
+{#each inlineLayoutPieces as { pieces, explodedRowY }}
 	{#if cutType === "vertical"}
 		{#each pieces as { pieceArea, subPieceIndex, cutX, cutNum, layerNumInColumn, explodedX }, index}
 			{@const isInCenterColumn = cutNum === 0}

--- a/src/components/onion/Onion.PieceAnalyzer.svelte
+++ b/src/components/onion/Onion.PieceAnalyzer.svelte
@@ -1,5 +1,5 @@
 <script>
-	import { run } from 'svelte/legacy';
+	import { run } from "svelte/legacy";
 
 	import { getContext, setContext } from "svelte";
 	import { interpolateHcl, scaleLinear, scaleSequential } from "d3";
@@ -21,57 +21,63 @@
 		meanArea,
 		standardDeviation
 	} = $derived($onionStore);
-	let verticalPieces = $derived(verticalAreas
-		.flatMap(({ cutX, pieceColumn }, cutNum) =>
-			pieceColumn.flatMap((piece, layerNumInColumn) => {
-				const pieceForSVG = {
-					...piece,
-					cutX,
-					cutNum,
-					layerNumInColumn
-				};
+	let verticalPieces = $derived(
+		verticalAreas
+			.flatMap(({ cutX, pieceColumn }, cutNum) =>
+				pieceColumn.flatMap((piece, layerNumInColumn) => {
+					const pieceForSVG = {
+						...piece,
+						cutX,
+						cutNum,
+						layerNumInColumn
+					};
 
-				return piece.subPieces.length
-					? piece.subPieces.map(({ subPieceArea, horizontalCutPathNum }) => ({
-							...pieceForSVG,
-							pieceArea: subPieceArea,
-							subPieceIndex: horizontalCutPathNum
-					  }))
-					: pieceForSVG;
-			})
-		)
-		.sort((a, b) => b.pieceArea - a.pieceArea));
-	let radialPieces = $derived(radialAreas
-		.flatMap(({ layerRadius, pieces }, layerNum) =>
-			pieces.flatMap((piece, pieceNum) => {
-				const pieceForSVG = {
-					...piece,
-					layerRadius,
-					layerNum,
-					numPieces: pieces.length,
-					isInnermostLayer: layerNum === 0,
-					isOutermostLayer: layerNum === radialAreas.length - 1,
-					pieceNum
-				};
+					return piece.subPieces.length
+						? piece.subPieces.map(({ subPieceArea, horizontalCutPathNum }) => ({
+								...pieceForSVG,
+								pieceArea: subPieceArea,
+								subPieceIndex: horizontalCutPathNum
+						  }))
+						: pieceForSVG;
+				})
+			)
+			.sort((a, b) => b.pieceArea - a.pieceArea)
+	);
+	let radialPieces = $derived(
+		radialAreas
+			.flatMap(({ layerRadius, pieces }, layerNum) =>
+				pieces.flatMap((piece, pieceNum) => {
+					const pieceForSVG = {
+						...piece,
+						layerRadius,
+						layerNum,
+						numPieces: pieces.length,
+						isInnermostLayer: layerNum === 0,
+						isOutermostLayer: layerNum === radialAreas.length - 1,
+						pieceNum
+					};
 
-				return piece.subPieces.length
-					? piece.subPieces.map(({ subPieceArea, horizontalCutPathNum }) => ({
-							...pieceForSVG,
-							area: subPieceArea,
-							subPieceIndex: horizontalCutPathNum
-					  }))
-					: pieceForSVG;
-			})
-		)
-		.sort((a, b) => b.area - a.area));
+					return piece.subPieces.length
+						? piece.subPieces.map(({ subPieceArea, horizontalCutPathNum }) => ({
+								...pieceForSVG,
+								area: subPieceArea,
+								subPieceIndex: horizontalCutPathNum
+						  }))
+						: pieceForSVG;
+				})
+			)
+			.sort((a, b) => b.area - a.area)
+	);
 
 	const explodeXScaleStore = writable();
-	let minArea =
-		$derived(cutType === "vertical"
+	let minArea = $derived(
+		cutType === "vertical"
 			? verticalPieces.at(-1).pieceArea
-			: radialPieces.at(-1).area);
-	let maxArea =
-		$derived(cutType === "vertical" ? verticalPieces[0].pieceArea : radialPieces[0].area);
+			: radialPieces.at(-1).area
+	);
+	let maxArea = $derived(
+		cutType === "vertical" ? verticalPieces[0].pieceArea : radialPieces[0].area
+	);
 	run(() => {
 		minArea,
 			maxArea,
@@ -82,8 +88,12 @@
 	setContext("explodeXScaleStore", explodeXScaleStore);
 
 	const colorScaleStore = writable();
-	let minStandardDeviations = $derived((minArea - meanArea) / standardDeviation);
-	let maxStandardDeviations = $derived((maxArea - meanArea) / standardDeviation);
+	let minStandardDeviations = $derived(
+		(minArea - meanArea) / standardDeviation
+	);
+	let maxStandardDeviations = $derived(
+		(maxArea - meanArea) / standardDeviation
+	);
 	// pieces with areas closer to average are more purple;
 	//   pieces with areas further from average are more orange
 	// TODO purple/orange are just placeholder colors
@@ -106,7 +116,7 @@
 
 <!-- TODO draw scale/ticks for exploded view? -->
 {#if cutType === "vertical"}
-	{#each verticalPieces as { layerRadius, pieceArea, yRange, subPieceIndex, cutX, cutNum, layerNumInColumn }}
+	{#each verticalPieces as { layerRadius, pieceArea, yRange, subPieceIndex, cutX, cutNum, layerNumInColumn }, index}
 		{@const isInCenterColumn = cutNum === 0}
 		{@const isBottomPiece = layerNumInColumn === 0}
 		{@const columnArcFunctions = layerArcs.filter(
@@ -136,6 +146,7 @@
 		{/if} -->
 
 		<OnionPiece
+			{index}
 			area={pieceArea}
 			layerNum={layerNumInColumn +
 				layerRadii.findLastIndex((r) => r <= cutX) +
@@ -148,7 +159,7 @@
 		/>
 	{/each}
 {:else if cutType === "radial"}
-	{#each radialPieces as { xOfLeftCutIntersection, xRange, area, yRange, subPieceIndex, cutNum, layerRadius, layerNum, numPieces, isInnermostLayer, isOutermostLayer, pieceNum }}
+	{#each radialPieces as { xOfLeftCutIntersection, xRange, area, yRange, subPieceIndex, cutNum, layerRadius, layerNum, numPieces, isInnermostLayer, isOutermostLayer, pieceNum }, index}
 		{@const x = xOfLeftCutIntersection}
 		{@const layerArcFunction = layerArcs[layerNum]}
 		{@const y = layerArcFunction(x)}
@@ -157,6 +168,7 @@
 			cutTargetDepthPercentage !== 0 && pieceNum === numPieces - 1}
 
 		<OnionPiece
+			{index}
 			{area}
 			{layerNum}
 			{cutNum}

--- a/src/components/onion/Onion.PieceAnalyzer.svelte
+++ b/src/components/onion/Onion.PieceAnalyzer.svelte
@@ -203,11 +203,7 @@
 			/>
 		{/each}
 	{:else if cutType === "radial"}
-		{#each pieces as { xOfLeftCutIntersection, xRange, area, yRange, subPieceIndex, cutNum, layerRadius, layerNum, numPieces, isInnermostLayer, isOutermostLayer, pieceNum, explodedX }, index}
-			{@const x = xOfLeftCutIntersection}
-			{@const layerArcFunction = layerArcs[layerNum]}
-			{@const y = layerArcFunction(x)}
-			{@const yNormalized = yScale(y)}
+		{#each pieces as { area, subPieceIndex, cutNum, layerNum, numPieces, isInnermostLayer, isOutermostLayer, pieceNum, explodedX }, index}
 			{@const isBottomPiece =
 				cutTargetDepthPercentage !== 0 && pieceNum === numPieces - 1}
 
@@ -224,42 +220,6 @@
 				{explodedX}
 				explodedRowY={explodedRowY ?? 0}
 			/>
-
-			<!-- <text {x} y={yNormalized} font-size="x-small">
-		({Math.round(x)}, {Math.round(y)})
-		</text> -->
-			<!-- <text {x} y={yNormalized} font-size="x-small">
-		{Math.round(area)}
-	</text> -->
-
-			<!-- <circle cx={x} cy={yNormalized} r="2" fill="red" /> -->
-
-			<!-- {#if numHorizontalCuts && subPieces.length}
-		<text
-			{x}
-			y={yNormalized}
-			font-size="xx-small"
-			alignment-baseline="hanging"
-			fill={yRangeColors[subPieces.length]}
-		>
-			y &isin; [{Math.round(yRange[0])},{Math.round(yRange[1])}]
-			{JSON.stringify(subPieces.map(Math.round))}
-		</text>
-	{/if} -->
-
-			<!-- {@const markerY = yScale(layerArcFunction(xOfLeftCutIntersection))} -->
-			<!-- <text {x} y={markerY} font-size="x-small">
-		[{Math.round(xRange[0])}, {Math.round(xRange[1])}]
-	</text> -->
-
-			<!-- <line
-		x1={xRange[0]}
-		y1={markerY}
-		x2={xRange[1]}
-		y2={markerY}
-		stroke-width="2"
-		style="stroke: red"
-	/> -->
 		{/each}
 	{/if}
 {/each}

--- a/src/components/onion/Onion.PieceAnalyzer.svelte
+++ b/src/components/onion/Onion.PieceAnalyzer.svelte
@@ -131,20 +131,20 @@
 					piece.layerNumInColumn +
 						layerRadii.findLastIndex((r) => r <= piece.cutX) +
 						1;
+				const isSubpiece = piece.subPieceIndex !== undefined;
 				const layerPath = $layerPathStore[layerNum];
 				const cutPath = $cutPathStore[piece.cutNum];
 				const piecePath = layerPath.intersect(cutPath);
 				const subPiecePath = piecePath.intersect(
 					$horizontalCutPathStore[piece.subPieceIndex]
 				);
-				const { width, height } = (
-					piece.subPieceIndex === undefined ? piecePath : subPiecePath
-				).strokeBounds;
+				const ownPath = isSubpiece ? subPiecePath : piecePath;
+				let { width, height } = ownPath.strokeBounds;
 				// TODO should these dimensions be set in onion.js instead?
 				piece.width = width;
 				piece.height = height;
 				piece.explodedX =
-					width / 2 - piecePath.position.x - svgWidth / 2 + EXPLODED_GAP;
+					width / 2 - ownPath.position.x - svgWidth / 2 + EXPLODED_GAP;
 
 				const lastRowWidth = rows.length ? lastRow.explodedRowWidth : 0;
 				const remainingWidth = svgWidth - lastRowWidth - EXPLODED_GAP;
@@ -197,7 +197,7 @@
 				primary={isInCenterColumn}
 				secondary={isBottomPiece}
 				{explodedX}
-				explodedRowY={explodedRowY ?? 0}
+				{explodedRowY}
 			/>
 		{/each}
 	{:else if cutType === "radial"}
@@ -215,7 +215,7 @@
 					isBottomPiece}
 				secondary={cutTargetDepthPercentage === 0 && isInnermostLayer}
 				{explodedX}
-				explodedRowY={explodedRowY ?? 0}
+				{explodedRowY}
 			/>
 		{/each}
 	{/if}

--- a/src/components/onion/Onion.PieceAnalyzer.svelte
+++ b/src/components/onion/Onion.PieceAnalyzer.svelte
@@ -5,6 +5,7 @@
 	import { interpolateHcl, scaleLinear, scaleSequential } from "d3";
 	import OnionPiece from "$components/onion/Onion.Piece.svelte";
 	import { writable } from "svelte/store";
+	import { EXPLODED_GAP } from "$utils/constants";
 
 	let { yScale, highlightExtremes } = $props();
 
@@ -133,21 +134,20 @@
 			const subPiecePath = piecePath.intersect(
 				$horizontalCutPathStore[piece.subPieceIndex]
 			);
-			// TODO should we set each piece's x-coordinate too?
 			const { width, height } = (
 				piece.subPieceIndex === undefined ? piecePath : subPiecePath
 			).strokeBounds;
 			// TODO should these dimensions be set in onion.js instead?
 			piece.width = width;
 			piece.height = height;
-			piece.explodedX = width / 2 - piecePath.position.x - svgWidth / 2;
+			piece.explodedX =
+				width / 2 - piecePath.position.x - svgWidth / 2 + EXPLODED_GAP;
 
 			const lastRowWidth = rows.length ? lastRow.explodedRowWidth : 0;
-			const remainingWidth = svgWidth - lastRowWidth;
-			const additionalWidth = width;
+			const remainingWidth = svgWidth - lastRowWidth - EXPLODED_GAP;
+			const additionalWidth = width + EXPLODED_GAP;
 
 			// if there is enough width in the last row to fit this piece, add it
-			// TODO account for gaps between pieces
 			if (rows.length && additionalWidth <= remainingWidth) {
 				piece.explodedX += lastRowWidth;
 				lastRow.pieces.push(piece);
@@ -159,8 +159,10 @@
 					? Math.max(...lastRow.pieces.map((p) => p.height))
 					: 0;
 				const explodedRowY =
-					rows.reduce((rowHeights, row) => rowHeights + row.explodedRowY, 0) +
-					tallestPieceHeight;
+					rows.reduce(
+						(rowHeights, row) => rowHeights + row.explodedRowY,
+						EXPLODED_GAP
+					) + tallestPieceHeight;
 
 				rows.push({
 					pieces: [piece],

--- a/src/components/onion/Onion.PieceAnalyzer.svelte
+++ b/src/components/onion/Onion.PieceAnalyzer.svelte
@@ -182,12 +182,11 @@
 <!-- TODO draw scale/ticks for exploded view? -->
 {#each inlineLayoutPieces as { pieces, explodedRowY }}
 	{#if cutType === "vertical"}
-		{#each pieces as { pieceArea, subPieceIndex, cutX, cutNum, layerNumInColumn, explodedX }, index}
+		{#each pieces as { pieceArea, subPieceIndex, cutX, cutNum, layerNumInColumn, explodedX }}
 			{@const isInCenterColumn = cutNum === 0}
 			{@const isBottomPiece = layerNumInColumn === 0}
 
 			<OnionPiece
-				{index}
 				area={pieceArea}
 				layerNum={layerNumInColumn +
 					layerRadii.findLastIndex((r) => r <= cutX) +
@@ -202,12 +201,11 @@
 			/>
 		{/each}
 	{:else if cutType === "radial"}
-		{#each pieces as { area, subPieceIndex, cutNum, layerNum, numPieces, isInnermostLayer, isOutermostLayer, pieceNum, explodedX }, index}
+		{#each pieces as { area, subPieceIndex, cutNum, layerNum, numPieces, isInnermostLayer, isOutermostLayer, pieceNum, explodedX }}
 			{@const isBottomPiece =
 				cutTargetDepthPercentage !== 0 && pieceNum === numPieces - 1}
 
 			<OnionPiece
-				{index}
 				{area}
 				{layerNum}
 				{cutNum}

--- a/src/components/onion/Onion.PieceAnalyzer.svelte
+++ b/src/components/onion/Onion.PieceAnalyzer.svelte
@@ -133,7 +133,6 @@
 			const subPiecePath = piecePath.intersect(
 				$horizontalCutPathStore[piece.subPieceIndex]
 			);
-			// TODO pass height to rows
 			// TODO should we set each piece's x-coordinate too?
 			const { width, height } = (
 				piece.subPieceIndex === undefined ? piecePath : subPiecePath
@@ -142,18 +141,15 @@
 			piece.width = width;
 			piece.height = height;
 
-			const lastRowWidth = rows.length
-				? lastRow.pieces.reduce(
-						(totalWidth, piece) => totalWidth + piece.width,
-						0
-				  )
-				: 0;
+			const lastRowWidth = rows.length ? lastRow.explodedRowWidth : 0;
 			const remainingWidth = svgWidth - lastRowWidth;
+			const additionalWidth = width;
 
 			// if there is enough width in the last row to fit this piece, add it
 			// TODO account for gaps between pieces
-			if (rows.length && width <= remainingWidth) {
+			if (rows.length && additionalWidth <= remainingWidth) {
 				lastRow.pieces.push(piece);
+				lastRow.explodedRowWidth += additionalWidth;
 			} else {
 				// otherwise, add it to a new row
 				// but first, take note of the tallest piece in the last row; the new row will sit below it
@@ -164,7 +160,11 @@
 					rows.reduce((rowHeights, row) => rowHeights + row.explodedRowY, 0) +
 					tallestPieceHeight;
 
-				rows.push({ pieces: [piece], explodedRowY });
+				rows.push({
+					pieces: [piece],
+					explodedRowY,
+					explodedRowWidth: additionalWidth
+				});
 			}
 
 			return rows;

--- a/src/components/onion/Onion.PieceAnalyzer.svelte
+++ b/src/components/onion/Onion.PieceAnalyzer.svelte
@@ -160,11 +160,9 @@
 					const tallestPieceHeight = lastRow
 						? Math.max(...lastRow.pieces.map((p) => p.height))
 						: 0;
-					const explodedRowY =
-						rows.reduce(
-							(rowHeights, row) => rowHeights + row.explodedRowY,
-							EXPLODED_GAP
-						) + tallestPieceHeight;
+					const explodedRowY = rows.length
+						? rows.at(-1).explodedRowY + tallestPieceHeight + EXPLODED_GAP
+						: EXPLODED_GAP;
 
 					rows.push({
 						pieces: [piece],

--- a/src/components/onion/Onion.PieceAnalyzer.svelte
+++ b/src/components/onion/Onion.PieceAnalyzer.svelte
@@ -173,6 +173,21 @@
 					});
 				}
 
+				let explodedY =
+					height / 2 - ownPath.position.y + rows.at(-1).explodedRowY;
+
+				// shift lower subpieces upward
+				if (isSubpiece) {
+					for (let i = piece.subPieceIndex; i < numHorizontalCuts; i++) {
+						const upperSubPiecePath = ownPath.intersect(
+							$horizontalCutPathStore[i + 1]
+						);
+						explodedY -= upperSubPiecePath.strokeBounds.height;
+					}
+				}
+
+				piece.explodedY = explodedY;
+
 				return rows;
 			},
 			[]
@@ -183,7 +198,7 @@
 <!-- TODO draw scale/ticks for exploded view? -->
 {#each inlineLayoutPieces as { pieces, explodedRowY }}
 	{#if cutType === "vertical"}
-		{#each pieces as { path, pieceArea, subPieceIndex, cutX, cutNum, layerNumInColumn, explodedX }}
+		{#each pieces as { path, pieceArea, subPieceIndex, cutX, cutNum, layerNumInColumn, explodedX, explodedY }}
 			{@const isInCenterColumn = cutNum === 0}
 			{@const isBottomPiece = layerNumInColumn === 0}
 
@@ -199,11 +214,11 @@
 				primary={isInCenterColumn}
 				secondary={isBottomPiece}
 				{explodedX}
-				{explodedRowY}
+				{explodedY}
 			/>
 		{/each}
 	{:else if cutType === "radial"}
-		{#each pieces as { path, area, subPieceIndex, cutNum, layerNum, numPieces, isInnermostLayer, isOutermostLayer, pieceNum, explodedX }}
+		{#each pieces as { path, area, subPieceIndex, cutNum, layerNum, numPieces, isInnermostLayer, isOutermostLayer, pieceNum, explodedX, explodedY }}
 			{@const isBottomPiece =
 				cutTargetDepthPercentage !== 0 && pieceNum === numPieces - 1}
 
@@ -218,7 +233,7 @@
 					isBottomPiece}
 				secondary={cutTargetDepthPercentage === 0 && isInnermostLayer}
 				{explodedX}
-				{explodedRowY}
+				{explodedY}
 			/>
 		{/each}
 	{/if}

--- a/src/components/onion/Onion.PieceAnalyzer.svelte
+++ b/src/components/onion/Onion.PieceAnalyzer.svelte
@@ -139,6 +139,7 @@
 					$horizontalCutPathStore[piece.subPieceIndex]
 				);
 				const ownPath = isSubpiece ? subPiecePath : piecePath;
+				piece.path = ownPath;
 				let { width, height } = ownPath.strokeBounds;
 				// TODO should these dimensions be set in onion.js instead?
 				piece.width = width;
@@ -182,11 +183,12 @@
 <!-- TODO draw scale/ticks for exploded view? -->
 {#each inlineLayoutPieces as { pieces, explodedRowY }}
 	{#if cutType === "vertical"}
-		{#each pieces as { pieceArea, subPieceIndex, cutX, cutNum, layerNumInColumn, explodedX }}
+		{#each pieces as { path, pieceArea, subPieceIndex, cutX, cutNum, layerNumInColumn, explodedX }}
 			{@const isInCenterColumn = cutNum === 0}
 			{@const isBottomPiece = layerNumInColumn === 0}
 
 			<OnionPiece
+				{path}
 				area={pieceArea}
 				layerNum={layerNumInColumn +
 					layerRadii.findLastIndex((r) => r <= cutX) +
@@ -201,11 +203,12 @@
 			/>
 		{/each}
 	{:else if cutType === "radial"}
-		{#each pieces as { area, subPieceIndex, cutNum, layerNum, numPieces, isInnermostLayer, isOutermostLayer, pieceNum, explodedX }}
+		{#each pieces as { path, area, subPieceIndex, cutNum, layerNum, numPieces, isInnermostLayer, isOutermostLayer, pieceNum, explodedX }}
 			{@const isBottomPiece =
 				cutTargetDepthPercentage !== 0 && pieceNum === numPieces - 1}
 
 			<OnionPiece
+				{path}
 				{area}
 				{layerNum}
 				{cutNum}

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -5,3 +5,4 @@ export const MAX_CUTS = 10;
 export const MIN_HORIZONTAL_CUTS = 0;
 export const MAX_HORIZONTAL_CUTS = 2;
 export const ESCAPED_NBSP = "\xa0";
+export const EXPLODED_GAP = 2;

--- a/src/utils/math.js
+++ b/src/utils/math.js
@@ -112,3 +112,11 @@ export function flattenRadialAreas(radialAreas) {
 		)
 		.flat(2);
 }
+
+// adding/subtracting integrals to obtain areas means our precision is off by a little;
+// rounding areas to 10 decimal places before comparing them makes the exploded sort order more visually appealing
+// (for pieces with equal areas, i.e., cutTargetDepth === 0, left-to-right order is preserved)
+export function compareRadialPieceAreasDescending(a, b) {
+	const numDecimalPlaces = 10;
+	return +b.area.toFixed(numDecimalPlaces) - +a.area.toFixed(numDecimalPlaces);
+}


### PR DESCRIPTION
closes #33 

- [x] vertically cut pieces
- [x] add gaps between exploded pieces
- [x] radially cut pieces
- [x] horizontally cut subpieces
- [x] tween viewBox height if necessary
