### PR TITLE
feat: display standard deviation rating along with number

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
 		"rollup": "^4.6.0",
 		"rollup-plugin-svg": "^2.0.0",
 		"style-dictionary": "^3.9.0",
-		"svelte": "^5.0.0",
+		"svelte": "^5.37.2",
 		"svelte-copy": "^1.4.1",
 		"svelte-preprocess": "^6.0.0",
 		"vite": "^5.4.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,13 +20,13 @@ importers:
         version: 3.0.4(rollup@4.6.0)
       '@sveltejs/adapter-static':
         specifier: ^3.0.0
-        version: 3.0.8(@sveltejs/kit@2.17.1(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.19.8)(vite@5.4.14))(svelte@5.19.8)(vite@5.4.14))
+        version: 3.0.8(@sveltejs/kit@2.17.1(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.37.2)(vite@5.4.14))(svelte@5.37.2)(vite@5.4.14))
       '@sveltejs/kit':
         specifier: ^2.5.27
-        version: 2.17.1(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.19.8)(vite@5.4.14))(svelte@5.19.8)(vite@5.4.14)
+        version: 2.17.1(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.37.2)(vite@5.4.14))(svelte@5.37.2)(vite@5.4.14)
       '@sveltejs/vite-plugin-svelte':
         specifier: ^4.0.0
-        version: 4.0.4(svelte@5.19.8)(vite@5.4.14)
+        version: 4.0.4(svelte@5.37.2)(vite@5.4.14)
       archieml:
         specifier: ^0.5.0
         version: 0.5.0
@@ -38,13 +38,13 @@ importers:
         version: 7.8.5
       layercake:
         specifier: ^8.0.2
-        version: 8.0.2(svelte@5.19.8)(typescript@5.3.2)
+        version: 8.0.2(svelte@5.37.2)(typescript@5.3.2)
       lodash.debounce:
         specifier: ^4.0.8
         version: 4.0.8
       lucide-svelte:
         specifier: ^0.294.0
-        version: 0.294.0(svelte@5.19.8)
+        version: 0.294.0(svelte@5.37.2)
       postcss:
         specifier: ^8.4.29
         version: 8.4.31
@@ -53,7 +53,7 @@ importers:
         version: 3.1.0
       prettier-plugin-svelte:
         specifier: ^3.2.6
-        version: 3.3.3(prettier@3.1.0)(svelte@5.19.8)
+        version: 3.3.3(prettier@3.1.0)(svelte@5.37.2)
       rollup:
         specifier: ^4.6.0
         version: 4.6.0
@@ -64,14 +64,14 @@ importers:
         specifier: ^3.9.0
         version: 3.9.0
       svelte:
-        specifier: ^5.0.0
-        version: 5.19.8
+        specifier: ^5.37.2
+        version: 5.37.2
       svelte-copy:
         specifier: ^1.4.1
-        version: 1.4.1(svelte@5.19.8)
+        version: 1.4.1(svelte@5.37.2)
       svelte-preprocess:
         specifier: ^6.0.0
-        version: 6.0.3(postcss@8.4.31)(svelte@5.19.8)(typescript@5.3.2)
+        version: 6.0.3(postcss@8.4.31)(svelte@5.37.2)(typescript@5.3.2)
       vite:
         specifier: ^5.4.4
         version: 5.4.14
@@ -230,16 +230,11 @@ packages:
     resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
-  '@jridgewell/gen-mapping@0.3.8':
-    resolution: {integrity: sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==}
-    engines: {node: '>=6.0.0'}
+  '@jridgewell/gen-mapping@0.3.12':
+    resolution: {integrity: sha512-OuLGC46TjB5BbN1dH8JULVVZY4WTdkF7tV9Ys6wLL1rubZnCMstOhNHueU5bLCrnRuDhKPDM4g6sw4Bel5Gzqg==}
 
-  '@jridgewell/resolve-uri@3.1.1':
-    resolution: {integrity: sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==}
-    engines: {node: '>=6.0.0'}
-
-  '@jridgewell/set-array@1.2.1':
-    resolution: {integrity: sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==}
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
     engines: {node: '>=6.0.0'}
 
   '@jridgewell/sourcemap-codec@1.4.15':
@@ -248,8 +243,11 @@ packages:
   '@jridgewell/sourcemap-codec@1.5.0':
     resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
 
-  '@jridgewell/trace-mapping@0.3.25':
-    resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
+  '@jridgewell/sourcemap-codec@1.5.4':
+    resolution: {integrity: sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==}
+
+  '@jridgewell/trace-mapping@0.3.29':
+    resolution: {integrity: sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ==}
 
   '@polka/url@1.0.0-next.28':
     resolution: {integrity: sha512-8LduaNlMZGwdZ6qWrKlfa+2M4gahzFkprZiAt2TF8uS0qQgBizKXpXURqvTJ4WtmupWxaLqjRb2UCTe72mu+Aw==}
@@ -429,6 +427,11 @@ packages:
   '@sinclair/typebox@0.27.8':
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
 
+  '@sveltejs/acorn-typescript@1.0.5':
+    resolution: {integrity: sha512-IwQk4yfwLdibDlrXVE04jTZYlLnwsTT2PIOQQGNLWfjavGifnk1JD1LcZjZaBTRcxZu2FfPfNLOE04DSu9lqtQ==}
+    peerDependencies:
+      acorn: ^8.9.0
+
   '@sveltejs/adapter-static@3.0.8':
     resolution: {integrity: sha512-YaDrquRpZwfcXbnlDsSrBQNCChVOT9MGuSg+dMAyfsAa1SmiAhrA5jUYUiIMC59G92kIbY/AaQOWcBdq+lh+zg==}
     peerDependencies:
@@ -560,6 +563,9 @@ packages:
   '@types/estree@1.0.6':
     resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
 
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
   '@types/geojson@7946.0.14':
     resolution: {integrity: sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg==}
 
@@ -578,11 +584,6 @@ packages:
   '@vitest/utils@1.1.3':
     resolution: {integrity: sha512-Dyt3UMcdElTll2H75vhxfpZu03uFpXRCHxWnzcrFjZxT1kTbq8ALUYIeBgGolo1gldVdI0YSlQRacsqxTwNqwg==}
 
-  acorn-typescript@1.4.13:
-    resolution: {integrity: sha512-xsc9Xv0xlVfwp2o7sQ+GCQ1PgbkdcpWdTzrwXxO3xDMTAywVS3oXVOcOHuRjAPkS4P9b+yc/qNF15460v+jp4Q==}
-    peerDependencies:
-      acorn: '>=8.9.0'
-
   acorn-walk@8.3.2:
     resolution: {integrity: sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==}
     engines: {node: '>=0.4.0'}
@@ -592,8 +593,8 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  acorn@8.14.0:
-    resolution: {integrity: sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==}
+  acorn@8.15.0:
+    resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
 
@@ -885,8 +886,8 @@ packages:
   esm-env@1.2.2:
     resolution: {integrity: sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==}
 
-  esrap@1.4.3:
-    resolution: {integrity: sha512-Xddc1RsoFJ4z9nR7W7BFaEPIp4UXoeQ0+077UdWLxbafMQFyU79sQJMk7kxNgRwQ9/aVgaKacCHC2pUACGwmYw==}
+  esrap@2.1.0:
+    resolution: {integrity: sha512-yzmPNpl7TBbMRC5Lj2JlJZNPml0tzqoqP5B1JXycNUwtqma9AKCO0M2wHrdgsHcy1WRW7S9rJknAMtByg3usgA==}
 
   estree-walker@0.2.1:
     resolution: {integrity: sha512-6/I1dwNKk0N9iGOU3ydzAAurz4NPo/ttxZNCqgIVbWFvWyzWBSNonRrJ5CpjDuyBfmM7ENN7WCzUi9aT/UPXXQ==}
@@ -1287,8 +1288,8 @@ packages:
       typescript:
         optional: true
 
-  svelte@5.19.8:
-    resolution: {integrity: sha512-56Vd/nwJrljV0w7RCV1A8sB4/yjSbWW5qrGDTAzp7q42OxwqEWT+6obWzDt41tHjIW+C9Fs2ygtejjJrXR+ZPA==}
+  svelte@5.37.2:
+    resolution: {integrity: sha512-SAakJiy04/OvXRAUnGxRACGzw6GB9kmxYIjuMO/zTcTL6psqc54Y0O/yR6I3OLqFqn79EPd23qsCGkKozvYYbQ==}
     engines: {node: '>=18'}
 
   tinybench@2.5.1:
@@ -1440,8 +1441,8 @@ snapshots:
 
   '@ampproject/remapping@2.3.0':
     dependencies:
-      '@jridgewell/gen-mapping': 0.3.8
-      '@jridgewell/trace-mapping': 0.3.25
+      '@jridgewell/gen-mapping': 0.3.12
+      '@jridgewell/trace-mapping': 0.3.29
 
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
@@ -1516,24 +1517,23 @@ snapshots:
     dependencies:
       '@sinclair/typebox': 0.27.8
 
-  '@jridgewell/gen-mapping@0.3.8':
+  '@jridgewell/gen-mapping@0.3.12':
     dependencies:
-      '@jridgewell/set-array': 1.2.1
-      '@jridgewell/sourcemap-codec': 1.5.0
-      '@jridgewell/trace-mapping': 0.3.25
+      '@jridgewell/sourcemap-codec': 1.5.4
+      '@jridgewell/trace-mapping': 0.3.29
 
-  '@jridgewell/resolve-uri@3.1.1': {}
-
-  '@jridgewell/set-array@1.2.1': {}
+  '@jridgewell/resolve-uri@3.1.2': {}
 
   '@jridgewell/sourcemap-codec@1.4.15': {}
 
   '@jridgewell/sourcemap-codec@1.5.0': {}
 
-  '@jridgewell/trace-mapping@0.3.25':
+  '@jridgewell/sourcemap-codec@1.5.4': {}
+
+  '@jridgewell/trace-mapping@0.3.29':
     dependencies:
-      '@jridgewell/resolve-uri': 3.1.1
-      '@jridgewell/sourcemap-codec': 1.5.0
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.4
 
   '@polka/url@1.0.0-next.28': {}
 
@@ -1649,13 +1649,17 @@ snapshots:
 
   '@sinclair/typebox@0.27.8': {}
 
-  '@sveltejs/adapter-static@3.0.8(@sveltejs/kit@2.17.1(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.19.8)(vite@5.4.14))(svelte@5.19.8)(vite@5.4.14))':
+  '@sveltejs/acorn-typescript@1.0.5(acorn@8.15.0)':
     dependencies:
-      '@sveltejs/kit': 2.17.1(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.19.8)(vite@5.4.14))(svelte@5.19.8)(vite@5.4.14)
+      acorn: 8.15.0
 
-  '@sveltejs/kit@2.17.1(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.19.8)(vite@5.4.14))(svelte@5.19.8)(vite@5.4.14)':
+  '@sveltejs/adapter-static@3.0.8(@sveltejs/kit@2.17.1(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.37.2)(vite@5.4.14))(svelte@5.37.2)(vite@5.4.14))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 4.0.4(svelte@5.19.8)(vite@5.4.14)
+      '@sveltejs/kit': 2.17.1(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.37.2)(vite@5.4.14))(svelte@5.37.2)(vite@5.4.14)
+
+  '@sveltejs/kit@2.17.1(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.37.2)(vite@5.4.14))(svelte@5.37.2)(vite@5.4.14)':
+    dependencies:
+      '@sveltejs/vite-plugin-svelte': 4.0.4(svelte@5.37.2)(vite@5.4.14)
       '@types/cookie': 0.6.0
       cookie: 0.6.0
       devalue: 5.1.1
@@ -1667,26 +1671,26 @@ snapshots:
       sade: 1.8.1
       set-cookie-parser: 2.6.0
       sirv: 3.0.0
-      svelte: 5.19.8
+      svelte: 5.37.2
       vite: 5.4.14
 
-  '@sveltejs/vite-plugin-svelte-inspector@3.0.1(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.19.8)(vite@5.4.14))(svelte@5.19.8)(vite@5.4.14)':
+  '@sveltejs/vite-plugin-svelte-inspector@3.0.1(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.37.2)(vite@5.4.14))(svelte@5.37.2)(vite@5.4.14)':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 4.0.4(svelte@5.19.8)(vite@5.4.14)
+      '@sveltejs/vite-plugin-svelte': 4.0.4(svelte@5.37.2)(vite@5.4.14)
       debug: 4.4.0
-      svelte: 5.19.8
+      svelte: 5.37.2
       vite: 5.4.14
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.19.8)(vite@5.4.14)':
+  '@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.37.2)(vite@5.4.14)':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 3.0.1(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.19.8)(vite@5.4.14))(svelte@5.19.8)(vite@5.4.14)
+      '@sveltejs/vite-plugin-svelte-inspector': 3.0.1(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.37.2)(vite@5.4.14))(svelte@5.37.2)(vite@5.4.14)
       debug: 4.4.0
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.17
-      svelte: 5.19.8
+      svelte: 5.37.2
       vite: 5.4.14
       vitefu: 1.0.5(vite@5.4.14)
     transitivePeerDependencies:
@@ -1815,6 +1819,8 @@ snapshots:
 
   '@types/estree@1.0.6': {}
 
+  '@types/estree@1.0.8': {}
+
   '@types/geojson@7946.0.14': {}
 
   '@vitest/expect@1.1.3':
@@ -1846,15 +1852,11 @@ snapshots:
       loupe: 2.3.7
       pretty-format: 29.7.0
 
-  acorn-typescript@1.4.13(acorn@8.14.0):
-    dependencies:
-      acorn: 8.14.0
-
   acorn-walk@8.3.2: {}
 
   acorn@8.11.2: {}
 
-  acorn@8.14.0: {}
+  acorn@8.15.0: {}
 
   ansi-styles@4.3.0:
     dependencies:
@@ -2190,9 +2192,9 @@ snapshots:
 
   esm-env@1.2.2: {}
 
-  esrap@1.4.3:
+  esrap@2.1.0:
     dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.0
+      '@jridgewell/sourcemap-codec': 1.5.4
 
   estree-walker@0.2.1: {}
 
@@ -2272,7 +2274,7 @@ snapshots:
 
   is-reference@3.0.3:
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.8
 
   is-stream@3.0.0: {}
 
@@ -2290,13 +2292,13 @@ snapshots:
 
   kleur@4.1.5: {}
 
-  layercake@8.0.2(svelte@5.19.8)(typescript@5.3.2):
+  layercake@8.0.2(svelte@5.37.2)(typescript@5.3.2):
     dependencies:
       d3-array: 3.2.4
       d3-color: 3.1.0
       d3-scale: 4.0.2
       d3-shape: 3.2.0
-      svelte: 5.19.8
+      svelte: 5.37.2
       typescript: 5.3.2
 
   local-pkg@0.5.0:
@@ -2318,9 +2320,9 @@ snapshots:
     dependencies:
       tslib: 2.6.2
 
-  lucide-svelte@0.294.0(svelte@5.19.8):
+  lucide-svelte@0.294.0(svelte@5.37.2):
     dependencies:
-      svelte: 5.19.8
+      svelte: 5.37.2
 
   magic-string@0.30.17:
     dependencies:
@@ -2435,10 +2437,10 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  prettier-plugin-svelte@3.3.3(prettier@3.1.0)(svelte@5.19.8):
+  prettier-plugin-svelte@3.3.3(prettier@3.1.0)(svelte@5.37.2):
     dependencies:
       prettier: 3.1.0
-      svelte: 5.19.8
+      svelte: 5.37.2
 
   prettier@3.1.0: {}
 
@@ -2569,29 +2571,29 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
-  svelte-copy@1.4.1(svelte@5.19.8):
+  svelte-copy@1.4.1(svelte@5.37.2):
     dependencies:
-      svelte: 5.19.8
+      svelte: 5.37.2
 
-  svelte-preprocess@6.0.3(postcss@8.4.31)(svelte@5.19.8)(typescript@5.3.2):
+  svelte-preprocess@6.0.3(postcss@8.4.31)(svelte@5.37.2)(typescript@5.3.2):
     dependencies:
-      svelte: 5.19.8
+      svelte: 5.37.2
     optionalDependencies:
       postcss: 8.4.31
       typescript: 5.3.2
 
-  svelte@5.19.8:
+  svelte@5.37.2:
     dependencies:
       '@ampproject/remapping': 2.3.0
-      '@jridgewell/sourcemap-codec': 1.5.0
-      '@types/estree': 1.0.5
-      acorn: 8.14.0
-      acorn-typescript: 1.4.13(acorn@8.14.0)
+      '@jridgewell/sourcemap-codec': 1.5.4
+      '@sveltejs/acorn-typescript': 1.0.5(acorn@8.15.0)
+      '@types/estree': 1.0.8
+      acorn: 8.15.0
       aria-query: 5.3.2
       axobject-query: 4.1.0
       clsx: 2.1.1
       esm-env: 1.2.2
-      esrap: 1.4.3
+      esrap: 2.1.0
       is-reference: 3.0.3
       locate-character: 3.0.0
       magic-string: 0.30.17

--- a/src/components/Index.svelte
+++ b/src/components/Index.svelte
@@ -1,5 +1,6 @@
 <script>
-	import { getContext } from "svelte";
+	import { getContext, setContext } from "svelte";
+	import { quantile } from "d3";
 	import WIP from "$components/helpers/WIP.svelte";
 	import Intro from "./Intro.svelte";
 	import Story from "./Story.svelte";
@@ -7,10 +8,23 @@
 	import Appendix from "./Appendix.svelte";
 	// import Footer from "$components/Footer.svelte";
 
-	const copy = getContext("copy");
-	// const data = getContext("data");
+	const data = getContext("data");
 
-	// console.log({ copy });
+	// determine the quartiles we'll use to label RSD as very low, low, high, very high
+	const standardDeviations = Object.values(data);
+	const min = Math.min(...standardDeviations);
+	const q1 = quantile(standardDeviations, 0.25);
+	const median = quantile(standardDeviations, 0.5);
+	const q3 = quantile(standardDeviations, 0.75);
+	const max = Math.max(...standardDeviations);
+
+	setContext("rsdBuckets", {
+		min,
+		q1,
+		median,
+		q3,
+		max
+	});
 </script>
 
 <WIP />

--- a/src/components/onion/Onion.Demo.svelte
+++ b/src/components/onion/Onion.Demo.svelte
@@ -234,15 +234,10 @@
 			<h3>vertical cuts</h3>
 			<OnionStandardDeviationGraph /> -->
 			{#if showStandardDeviation}
-				<label class="standard-deviation">
-					standard deviation
-					<input
-						type="number"
-						readonly
-						bind:value={$onionStore.standardDeviationString}
-					/>
-					%
-				</label>
+				<p>
+					standard deviation:
+					<span>{$onionStore.standardDeviationString}</span>%
+				</p>
 			{/if}
 		</div>
 	{/if}
@@ -372,10 +367,6 @@
 
 		&.top {
 			margin-bottom: var(--demo-spacing-y);
-
-			& .standard-deviation {
-				display: block;
-			}
 		}
 
 		&.bottom {

--- a/src/routes/+page.server.js
+++ b/src/routes/+page.server.js
@@ -1,4 +1,8 @@
+import { readFile } from "fs/promises";
+
 export async function load() {
-	const data = ["a", "b", "c"];
+	const inputFile = await readFile("src/data/onion-standard-deviation.json");
+	const data = JSON.parse(inputFile);
+
 	return { data };
 }

--- a/tasks/onion-report.js
+++ b/tasks/onion-report.js
@@ -6,6 +6,7 @@ import {
 	MIN_CUTS,
 	MIN_LAYERS
 } from "../src/utils/constants.js";
+import { quantile } from "d3";
 
 const CWD = process.cwd();
 const DATA_DIRECTORY = path.join(CWD, "src/data");
@@ -46,6 +47,25 @@ async function findMinimumStandardDeviations(data) {
 	console.log(`Wrote onion report to ${outputFilename}`);
 }
 
+// determine the quartiles we'll use to label RSD as very low, low, high, very high
+// TODO run this after loading onion-standard-deviation.json in +page.svelte's load function
+function findBuckets(data) {
+	const standardDeviations = Object.values(data);
+	const minStandardDeviation = Math.min(...standardDeviations);
+	const q1StandardDeviation = quantile(standardDeviations, 0.25);
+	const medianStandardDeviation = quantile(standardDeviations, 0.5);
+	const q3StandardDeviation = quantile(standardDeviations, 0.75);
+	const maxStandardDeviation = Math.max(...standardDeviations);
+
+	console.log({
+		minStandardDeviation,
+		q1StandardDeviation,
+		medianStandardDeviation,
+		q3StandardDeviation,
+		maxStandardDeviation
+	});
+}
+
 (async () => {
 	try {
 		const inputFile = await readFile(
@@ -53,9 +73,10 @@ async function findMinimumStandardDeviations(data) {
 		);
 		const data = JSON.parse(inputFile);
 
-		await findMinimumStandardDeviations(data);
+		// await findMinimumStandardDeviations(data);
 
-		// TODO find the min, max, and median standard deviations, for determining RSD buckets
+		// TODO find the median standard deviation, for determining RSD buckets
+		findBuckets(data);
 	} catch (error) {
 		console.error(error);
 	}

--- a/tasks/onion-report.js
+++ b/tasks/onion-report.js
@@ -24,29 +24,38 @@ function getEntryWithMinimumValue(data) {
 	return Object.entries(data).find(([, value]) => value === minimumValue);
 }
 
+// find the minimum standard deviations for every layer/cut combo + how to obtain it
+//   (vertical, radial / what depth, horizontal if any)
+async function findMinimumStandardDeviations(data) {
+	let reportData = [];
+
+	for (let l = MIN_LAYERS; l <= MAX_LAYERS; l++) {
+		for (let c = MIN_CUTS; c <= MAX_CUTS; c++) {
+			const configurationData = getConfigurationData({
+				data,
+				numLayers: l,
+				numCuts: c
+			});
+			const e = getEntryWithMinimumValue(configurationData);
+			reportData.push(e);
+		}
+	}
+
+	await writeFile(outputFilename, JSON.stringify(reportData), "utf8");
+
+	console.log(`Wrote onion report to ${outputFilename}`);
+}
+
 (async () => {
 	try {
 		const inputFile = await readFile(
 			path.join(DATA_DIRECTORY, "onion-standard-deviation.json")
 		);
 		const data = JSON.parse(inputFile);
-		let reportData = [];
 
-		for (let l = MIN_LAYERS; l <= MAX_LAYERS; l++) {
-			for (let c = MIN_CUTS; c <= MAX_CUTS; c++) {
-				const configurationData = getConfigurationData({
-					data,
-					numLayers: l,
-					numCuts: c
-				});
-				const e = getEntryWithMinimumValue(configurationData);
-				reportData.push(e);
-			}
-		}
+		await findMinimumStandardDeviations(data);
 
-		await writeFile(outputFilename, JSON.stringify(reportData), "utf8");
-
-		console.log(`Wrote onion report to ${outputFilename}`);
+		// TODO find the min, max, and median standard deviations, for determining RSD buckets
 	} catch (error) {
 		console.error(error);
 	}

--- a/tasks/onion-report.js
+++ b/tasks/onion-report.js
@@ -6,7 +6,6 @@ import {
 	MIN_CUTS,
 	MIN_LAYERS
 } from "../src/utils/constants.js";
-import { quantile } from "d3";
 
 const CWD = process.cwd();
 const DATA_DIRECTORY = path.join(CWD, "src/data");
@@ -47,25 +46,6 @@ async function findMinimumStandardDeviations(data) {
 	console.log(`Wrote onion report to ${outputFilename}`);
 }
 
-// determine the quartiles we'll use to label RSD as very low, low, high, very high
-// TODO run this after loading onion-standard-deviation.json in +page.svelte's load function
-function findBuckets(data) {
-	const standardDeviations = Object.values(data);
-	const minStandardDeviation = Math.min(...standardDeviations);
-	const q1StandardDeviation = quantile(standardDeviations, 0.25);
-	const medianStandardDeviation = quantile(standardDeviations, 0.5);
-	const q3StandardDeviation = quantile(standardDeviations, 0.75);
-	const maxStandardDeviation = Math.max(...standardDeviations);
-
-	console.log({
-		minStandardDeviation,
-		q1StandardDeviation,
-		medianStandardDeviation,
-		q3StandardDeviation,
-		maxStandardDeviation
-	});
-}
-
 (async () => {
 	try {
 		const inputFile = await readFile(
@@ -73,10 +53,7 @@ function findBuckets(data) {
 		);
 		const data = JSON.parse(inputFile);
 
-		// await findMinimumStandardDeviations(data);
-
-		// TODO find the median standard deviation, for determining RSD buckets
-		findBuckets(data);
+		await findMinimumStandardDeviations(data);
 	} catch (error) {
 		console.error(error);
 	}


### PR DESCRIPTION
closes #23 

upgrades Svelte to 5.37.2 to enable `$props.id()` which was added in 5.20.0