### PR TITLE
feat: dynamically set numCuts label as vertical/radial

### DIFF
--- a/src/components/onion/Onion.Demo.svelte
+++ b/src/components/onion/Onion.Demo.svelte
@@ -302,7 +302,7 @@
 				{/if}
 
 				<div class="control-unit">
-					<span class="label">Cuts (vertical)</span>
+					<span class="label">Cuts ({cutType})</span>
 					<Range
 						min={MIN_CUTS}
 						max={MAX_CUTS}


### PR DESCRIPTION
now the label says "Cuts (radial)" when applicable