### PR TITLE
feat: remove highlight from horizontally cut subpieces

### DIFF
--- a/src/components/onion/Onion.Piece.svelte
+++ b/src/components/onion/Onion.Piece.svelte
@@ -80,14 +80,16 @@
 			stroke-width: 2px;
 		}
 
-		&.subpiece {
+		/* make subpieces more visible for debugging */
+		/*&.subpiece {
 			stroke: var(--color-primary);
-		}
+		}*/
 	}
 
-	:global(figure:not(.explode) .subpiece) {
+	/* make subpieces more visible for debugging */
+	/*:global(figure:not(.explode) .subpiece) {
 		stroke-width: 2px;
-	}
+	}*/
 
 	:global(figure.explode path) {
 		stroke: var(--onion-dark);


### PR DESCRIPTION
closes #51 

@russellsamora I couldn't repro the screenshot from the issue. It looks like the diagram in that screenshot has `highlightExtremes: true` like the second diagram in the article.

Did you mean you wanted to remove the highlight (thick solid stroke) from horizontally cut subpieces? That does look better in both exploded/unexploded

## before

https://github.com/user-attachments/assets/76673af6-cc13-471d-ab94-1fbcede4a2ee

## after

https://github.com/user-attachments/assets/3ab9e980-e298-4a32-b3c2-26b0576102c3