### PR TITLE
fix: remove shadow from range slider thumb

### DIFF
--- a/src/components/helpers/Range.svelte
+++ b/src/components/helpers/Range.svelte
@@ -71,6 +71,7 @@
 		background-size: contain;
 		appearance: none;
 		margin-top: calc(var(--thumb-width) / -3);
+		box-shadow: none;
 	}
 
 	input[type="range"]:focus::-webkit-slider-runnable-track {


### PR DESCRIPTION
some browsers like iOS Chrome and iOS Safari add a shadow to a range slider's thumb

## before

<img width="1170" height="2532" alt="IMG_2529" src="https://github.com/user-attachments/assets/67ff6061-97ef-4717-b062-cd82c234a918" />

## after

<img width="1170" height="2532" alt="IMG_2530" src="https://github.com/user-attachments/assets/52ef9c85-f479-45c2-ae8a-c28705a5fd4d" />